### PR TITLE
Rework CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ cicd, master ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,24 +79,14 @@ jobs:
           rm -f docker-compose.yml
           rm -f README.md
 
-      - name: Get current date
-        uses: 1466587594/get-current-time@v2.0.0
-        id: current-date
-        with:
-          format: YYYY-MM-DD-HHmmss
-
       - name: Create archive
-        env:
-          time: "${{ steps.current-date.outputs.formattedTime }}"
-        run: zip -r live.24hisere.fr-${{ env.time }}.zip .
+        run: zip -r live.24hisere.fr.zip .
 
       - name: Create artifact
-        env:
-          time: "${{ steps.current-date.outputs.formattedTime }}"
         uses: actions/upload-artifact@v3
         with:
           name: live.24hisere.fr-artifact
-          path: live.24hisere.fr-${{ env.time }}.zip
+          path: live.24hisere.fr.zip
           retention-days: 7
 
 
@@ -111,11 +101,10 @@ jobs:
         with:
           name: live.24hisere.fr-artifact
 
-      - name: List files
-        run: ls -al
+      - name: Unzip archive
+        run: unzip live.24hisere.fr.zip
 
-#      - name: Run PHP tests
-#        run: |
-#          pushd backend
-#          ./vendor/bin/phpunit --testdox tests
-#          popd
+      - name: Run PHP tests
+        run: |
+          ./vendor/bin/phpunit --testdox tests
+        working-directory: ./backend

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,16 +37,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install PHP dependencies
-        run: |
-          cd backend
-          composer install
-          cd ..
+        run: composer install
+        working-directory: ./backend
 
       - name: Install JS dependencies
-        run: |
-          cd frontend
-          npm install
-          cd ..
+        run: npm install
+        working-directory: ./frontend
 
       - name: Create frontend config file
         env:
@@ -54,10 +50,8 @@ jobs:
         run: echo ${FRONTEND_CONFIG_FILE_CONTENT} > frontend/src/config/config.js
 
       - name: Create frontend production builds
-        run: |
-          cd frontend
-          npm run build
-          cd ..
+        run: npm run build
+        working-directory: ./frontend
 
       - name: Clean files
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,49 +2,10 @@ name: CI/CD
 
 on:
   push:
-    branches: [ master ]
+    branches: [ cicd, master ]
 
 jobs:
-  test:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Update apt
-        run: sudo apt-get update
-
-      - name: Uninstall current PHP version
-        run: |
-          sudo apt-get purge 'php*'
-          sudo apt-get autoremove 'php*'
-
-      - name: Uninstall current Node.js version
-        run: |
-          sudo apt-get purge nodejs
-          sudo apt-get autoremove nodejs
-
-      - name: Install PHP 8.0
-        run: |
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:ondrej/php
-          sudo apt-get install -y php8.0 php8.0-mbstring php8.0-dom
-
-      - name: Check out repository code
-        uses: actions/checkout@v2
-
-      - name: Install PHP dependencies
-        run: |
-          pushd backend
-          composer install
-          popd
-
-      - name: Run PHP tests
-        run: |
-          pushd backend
-          ./vendor/bin/phpunit --testdox tests
-          popd
-
   build:
-    needs: test
     runs-on: ubuntu-20.04
 
     steps:
@@ -132,8 +93,29 @@ jobs:
       - name: Create artifact
         env:
           time: "${{ steps.current-date.outputs.formattedTime }}"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: live.24hisere.fr-artifact
           path: live.24hisere.fr-${{ env.time }}.zip
           retention-days: 7
+
+
+  test:
+    runs-on: ubuntu-20.04
+    container: php:8.0-cli-alpine3.15
+    needs: build
+
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v3
+        with:
+          name: live.24hisere.fr-artifact
+
+      - name: List files
+        run: ls -al
+
+#      - name: Run PHP tests
+#        run: |
+#          pushd backend
+#          ./vendor/bin/phpunit --testdox tests
+#          popd

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository ppa:ondrej/php
-          sudo apt-get install -y php8.0 php8.0-mbstring
+          sudo apt-get install -y php8.0 php8.0-mbstring php8.0-dom
 
       - name: Install Node.js 16
         run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Install PHP dependencies
         run: |
           cd backend
-          composer install --no-dev
+          composer install
           cd ..
 
       - name: Install JS dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ jobs:
         run: apt-get update
 
       - name: Install misc tools
-        run: apt-get install -y curl
+        run: apt-get install -y curl git
 
       - name: Install PHP 8.0
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,31 +7,30 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    container: ubuntu:20.04
 
     steps:
       - name: Update apt
-        run: sudo apt-get update
+        run: apt-get update
 
-      - name: Uninstall current PHP version
-        run: |
-          sudo apt-get purge 'php*'
-          sudo apt-get autoremove 'php*'
-
-      - name: Uninstall current Node.js version
-        run: |
-          sudo apt-get purge nodejs
-          sudo apt-get autoremove nodejs
+      - name: Install misc tools
+        run: apt-get install -y curl
 
       - name: Install PHP 8.0
         run: |
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:ondrej/php
-          sudo apt-get install -y php8.0 php8.0-mbstring php8.0-dom
+          apt-get install -y software-properties-common
+          add-apt-repository ppa:ondrej/php
+          apt-get install -y php8.0 php8.0-mbstring php8.0-dom
+
+      - name: Install Composer
+        run: |
+          curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+          php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
       - name: Install Node.js 16
         run: |
-          curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-          sudo apt-get install -y nodejs
+          curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+          apt-get install -y nodejs
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
         run: apt-get update
 
       - name: Install misc tools
-        run: apt-get install -y curl git
+        run: apt-get install -y curl git zip unzip
 
       - name: Install PHP 8.0
         run: |
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install PHP dependencies
-        run: composer install
+        run: composer install --no-cache
         working-directory: ./backend
 
       - name: Install JS dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-20.04
     container: ubuntu:20.04
 
+    env:
+      DEBIAN_FRONTEND: noninteractive # Prevent PHP installation to ask geographic zone and timezone
+
     steps:
       - name: Update apt
         run: apt-get update

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,6 +68,7 @@ jobs:
           rm -f frontend/.gitignore
           rm -f frontend/package.json
           rm -f frontend/package-lock.json
+          rm -rf import-passages
           rm -rf import
           rm -rf sql
           rm -f .gitattributes

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,6 +99,5 @@ jobs:
         run: unzip live.24hisere.fr.zip
 
       - name: Run PHP tests
-        run: |
-          ./vendor/bin/phpunit --testdox tests
+        run: ./vendor/bin/phpunit --testdox tests
         working-directory: ./backend


### PR DESCRIPTION
Restructuration du pipeline CI/CD

- Build dans un container Docker ubuntu vierge, pour ne pas avoir à désinstaller puis réinstaller PHP et Node.js dans la VM ubuntu fournie par GitHub
- Exécution des tests unitaires dans un container Docker en utilisant le build créé précédemment