### PR TITLE
Add step in cicd to use latest corepack version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,6 +28,14 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
           apt-get install -y nodejs
 
+      # Ensure we have the new signing keys that match the npm registry changes (corepack >= 0.31.0)
+      # See https://vercel.com/guides/corepack-errors-github-actions
+      - name: Use latest Corepack
+        run: |
+          echo "Before: corepack version: $(corepack --version || echo 'not installed')"
+          npm install -g corepack@latest
+          echo "After : corepack version: $(corepack --version)"
+
       - name: Enable corepack to use pnpm
         run: corepack enable
 


### PR DESCRIPTION
Fix corepack error "Cannot find matching keyid" (use corepack >= 0.31.0)